### PR TITLE
Modify temperture read + add alert example

### DIFF
--- a/INA238.cpp
+++ b/INA238.cpp
@@ -146,9 +146,12 @@ float INA238::getPower()
 //  PAGE 24  CHECK
 float INA238::getTemperature()
 {
-  uint32_t value = _readRegister(INA238_TEMPERATURE, 2);
-  // INA238 uses 16 bits for temperature with 7.8125 m°C/LSB
-  return (float)value * 7.8125 / 1000.0;
+  //  INA238 uses two complements, so place 2 bytes in int16_t
+  int16_t value = (int16_t) _readRegister(INA238_TEMPERATURE, 2);
+  // shift 4 right as INA238 uses only bits 15-4
+  value >>= 4;
+  float LSB = 125e-3;   //  125 m°C/LSB
+  return (float)value * LSB;
 }
 
 

--- a/INA238.cpp
+++ b/INA238.cpp
@@ -147,8 +147,8 @@ float INA238::getPower()
 float INA238::getTemperature()
 {
   uint32_t value = _readRegister(INA238_TEMPERATURE, 2);
-  float LSB = 125e-3;  //  125 milli degree Celsius
-  return value * LSB;
+  // INA238 uses 16 bits for temperature with 7.8125 m°C/LSB
+  return (float)value * 7.8125 / 1000.0;
 }
 
 
@@ -293,7 +293,7 @@ int INA238::setMaxCurrentShunt(float maxCurrent, float shunt)
   if (maxCurrent < 0.0) return -3;
   _maxCurrent = maxCurrent;
   _shunt = shunt;
-  _current_LSB = _maxCurrent * 3.0517578125e-5;  //  pow(2, -15);
+  _current_LSB = _maxCurrent / (float)(1UL << 15);  //  pow(2, -15);
 
   //  PAGE 28-29 (8.1.2)
   float shunt_cal = 819.2e6 * _current_LSB * _shunt;  //  8.1.2  formula (1,2)
@@ -379,6 +379,42 @@ uint16_t INA238::getDiagnoseAlertBit(uint8_t bit)
 //  - API
 //  - return bool for setters?
 //  - float voltage interface instead of uint16_t?  breaking!
+void INA238::setOverCurrentLimit(uint32_t milliamp)
+{
+    // Convert mA → A
+    float current_A = milliamp / 1000.0f;
+
+    // Compute shunt voltage
+    float v_shunt = current_A * _shunt;
+
+    // Determine LSB based on ADCRANGE
+    float lsb = _ADCRange ? 0.00000125f : 0.000005f;
+
+    // Convert volts → register value
+    uint16_t raw = (uint16_t)(v_shunt / lsb + 0.5f);
+
+    // Write to SOVL register
+    _writeRegister(INA238_SOVL, raw);
+}
+
+float INA238::getOverCurrentLimit_mA()
+{
+    // Read raw threshold register
+    uint16_t raw = _readRegister(INA238_SOVL, 2);
+
+    // Determine LSB based on ADCRANGE
+    float lsb = _ADCRange ? 0.00000125f : 0.000005f;
+
+    // Convert raw register → shunt voltage
+    float v_shunt = raw * lsb;
+
+    // Convert shunt voltage → current (A)
+    float current_A = v_shunt / _shunt;
+
+    // Convert A → mA
+    return current_A * 1000.0f;
+}
+
 void INA238::setShuntOvervoltageTH(uint16_t threshold)
 {
   //  ADCRANGE DEPENDENT

--- a/INA238.h
+++ b/INA238.h
@@ -1,7 +1,7 @@
 #pragma once
 //    FILE: INA238.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.2
+// VERSION: 0.1.3
 //    DATE: 2025-06-11
 // PURPOSE: Arduino library for the INA238, I2C, 16 bit, voltage, current and power sensor.
 //     URL: https://github.com/RobTillaart/INA238
@@ -14,7 +14,7 @@
 #include "Wire.h"
 
 
-#define INA238_LIB_VERSION          (F("0.1.2"))
+#define INA238_LIB_VERSION          (F("0.1.3"))
 
 
 //  for setMode() and getMode()
@@ -190,6 +190,9 @@ public:
   //  read datasheet for details, section 7.3.6, page 16++
   //                              section 7.6.1.10, page 26++
   //
+  void setOverCurrentLimit(uint32_t milliamp);
+  float getOverCurrentLimit_mA();
+  
   void     setShuntOvervoltageTH(uint16_t threshold);
   uint16_t getShuntOvervoltageTH();
   void     setShuntUndervoltageTH(uint16_t threshold);

--- a/README.md
+++ b/README.md
@@ -387,7 +387,8 @@ might be changed / extended in the future.
 Idem see my INA228 library.
 
 #### Shunt
-
+- **void setOverCurrentLimit(uint32_t milliamp)**
+- **float getOverCurrentLimit_mA()**
 - **void setShuntOvervoltageTH(uint16_t threshold)**
 - **uint16_t getShuntOvervoltageTH()**
 - **void setShuntUndervoltageTH(uint16_t threshold)**

--- a/examples/INA238_alertsetting/INA238_alertsetting.ino
+++ b/examples/INA238_alertsetting/INA238_alertsetting.ino
@@ -1,0 +1,59 @@
+//
+//    FILE: INA238_demo.ino
+//  AUTHOR: Rob Tillaart
+// PURPOSE: demo core functions
+//     URL: https://github.com/RobTillaart/INA238
+
+
+#include "INA238.h"
+
+
+INA238 INA(0x40);
+
+
+void setup()
+{
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println(__FILE__);
+  Serial.print("INA238_LIB_VERSION: ");
+  Serial.println(INA238_LIB_VERSION);
+  Serial.println();
+
+  Wire.begin();
+  if (!INA.begin() )
+  {
+    Serial.println("Could not connect. Fix and Reboot");
+    while(1);
+  }
+
+  INA.setADCRange(1);
+  INA.setMaxCurrentShunt(10, 0.015);
+  INA.setShuntVoltageConversionTime(INA238_150_us);
+  INA.setAverage(INA238_16_SAMPLES); 
+  INA.setOverCurrentLimit(2750); // in mA
+  INA.setDiagnoseAlertBit(INA238_DIAG_ALERT_LATCH); //Set to Alert latch
+}
+
+
+void loop()
+{
+  Serial.println("\nVBUS\tVSHUNT\tCURRENT\tPOWER\tTEMP");
+  for (int i = 0; i < 20; i++)
+  {
+    Serial.print(INA.getBusVoltage(), 3);
+    Serial.print("\t");
+    Serial.print(INA.getShuntMilliVolt(), 3);
+    Serial.print("\t");
+    Serial.print(INA.getMilliAmpere(), 3);
+    Serial.print("\t");
+    Serial.print(INA.getMilliWatt(), 3);
+    Serial.print("\t");
+    Serial.print(INA.getTemperature(), 3);
+    Serial.println();
+    delay(1000);
+  }
+}
+
+
+//  -- END OF FILE --


### PR DESCRIPTION
Changes:

- Update readTemperature(), previous code was not reading correctly. Example at room temp, older code was reading 400C.
- Clean up setMaxCurrentShunt by using 1 << 15 to represent 2^15
- Add void setOverCurrentLimit(uint32_t milliamp);
- Add float getOverCurrentLimit_mA();

The added function take into account the _shunt and also adcRange. These function allow easier setting for Alert flag if want to use INA238 as breaker trigger.

Tested on custom INA238 Board call RotoPD Pro, shunt resistance tested is 5miliOhm.

